### PR TITLE
Pass branch to clone as an argument

### DIFF
--- a/recorder/create-instance.sh
+++ b/recorder/create-instance.sh
@@ -1,4 +1,5 @@
 bucket=$1
+branch=$2
 
 gcloud compute instances create stream-archive-recorder \
   --image-project=debian-cloud \
@@ -8,4 +9,4 @@ gcloud compute instances create stream-archive-recorder \
   --resource-policies=restart-stream-recorder \
   --scopes=https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring.write,https://www.googleapis.com/auth/trace.append,https://www.googleapis.com/auth/devstorage.read_write \
   --metadata-from-file=startup-script=./startup.sh \
-  --metadata=BUCKET_NAME=${bucket}
+  --metadata=BUCKET_NAME=${bucket},BRANCH=${branch}

--- a/recorder/startup.sh
+++ b/recorder/startup.sh
@@ -4,7 +4,7 @@ apt-get install -yq git supervisor python3-pip python3-virtualenv
 
 # Fetch source code
 export HOME=/root
-git clone --single-branch --branch separate-recording-and-composing https://github.com/chirpradio/stream-archiver.git /opt/app
+git clone --branch $(curl http://metadata.google.internal/computeMetadata/v1/instance/attributes/BRANCH -H "Metadata-Flavor: Google") https://github.com/chirpradio/stream-archiver.git /opt/app
 
 # Install Cloud Ops Agent
 sudo bash /opt/app/recorder/add-google-cloud-ops-agent-repo.sh --also-install


### PR DESCRIPTION
Pass the branch to clone as an argument to the creation script, which sets it as custom metadata the instance can look up: https://cloud.google.com/compute/docs/metadata/setting-custom-metadata#set_metadata_during_creation

With this we can deploy the main branch to production or a WIP branch to dev.