### PR TITLE
Rotate logs

### DIFF
--- a/recorder/logrotate/rsyslog
+++ b/recorder/logrotate/rsyslog
@@ -1,0 +1,31 @@
+/var/log/mail.log
+/var/log/kern.log
+/var/log/auth.log
+/var/log/cron.log
+{
+        rotate 1
+        weekly
+        missingok
+        notifempty
+        compress
+        delaycompress
+        sharedscripts
+        postrotate
+                /usr/lib/rsyslog/rsyslog-rotate
+        endscript
+}
+
+/var/log/syslog
+/var/log/user.log
+{
+        rotate 0
+        daily
+        missingok
+        notifempty
+        compress
+        delaycompress
+        sharedscripts
+        postrotate
+                /usr/lib/rsyslog/rsyslog-rotate
+        endscript
+}

--- a/recorder/startup.sh
+++ b/recorder/startup.sh
@@ -1,6 +1,6 @@
 # Install or update needed software
 apt-get update
-apt-get install -yq git supervisor python3-pip python3-virtualenv
+apt-get install -yq git supervisor python3-pip python3-virtualenv logrotate
 
 # Fetch source code
 export HOME=/root
@@ -23,8 +23,9 @@ echo -n ,BUCKET_NAME=\"$(curl http://metadata.google.internal/computeMetadata/v1
 # Set ownership to newly created account
 chown -R recorder:recorder /opt/app
 
-# Put supervisor configuration in proper place
+# Put configuration files in place
 cp /opt/app/recorder/recorder.conf /etc/supervisor/conf.d/recorder.conf
+cp /opt/app/recorder/logrotate/rsyslog /etc/logrotate.d/rsyslog
 
 # Start service via supervisorctl
 supervisorctl reread


### PR DESCRIPTION
Adds `logrotate` to the server configuration to clean up log files that are already forwarded to Google Cloud Logging and avoid filling up the disk space allotted to the stream archive recorder.

Since the syslog and user.log fill up quickly, we rotate those daily and don't keep backups on disk. The other logs in that directory fill up more slowly and aren't all forwarded, so we can rotate those weekly and keep the previous week's logs on disk. This configuration keeps the recorder hovering around 50% of its 10GB capacity.


![Disk Space Utilization](https://github.com/chirpradio/stream-archiver/assets/772939/24727f8c-a283-46c8-bde1-b7c3a7ec50d2)

Useful overview of logrotate configuration: https://betterstack.com/community/guides/logging/how-to-manage-log-files-with-logrotate-on-ubuntu-20-04/ 